### PR TITLE
Add Related Knowledge section in prompts

### DIFF
--- a/core/prompt_manager.py
+++ b/core/prompt_manager.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable
+
+
+VALID_MODES = {"scan", "fix", "pr", "log"}
+
+def _format_related(related: Iterable[Any]) -> str:
+    """Return a formatted related knowledge section."""
+    lines = ["### Related Knowledge"]
+    for item in related:
+        title = item.get("title") if isinstance(item, dict) else str(item)
+        lines.append(f"\u2022 {title}")
+    return "\n".join(lines)
+
+
+def build_prompt(issue: Dict[str, Any], *, mode: str = "scan", **_: Any) -> str:
+    """Build a prompt string for the given ``issue`` and ``mode``."""
+    if mode not in VALID_MODES:
+        raise ValueError(f"Unsupported mode: {mode}")
+
+    parts = [issue.get("title", ""), issue.get("body", "")]
+    related = issue.get("related")
+    if related:
+        parts.append(_format_related(related))
+    prompt = "\n".join(p for p in parts if p)
+    return json.dumps({"mode": mode, "prompt": prompt})

--- a/tests/test_prompt_injection.py
+++ b/tests/test_prompt_injection.py
@@ -1,0 +1,21 @@
+import json
+
+from core.prompt_manager import build_prompt
+
+
+def test_prompt_includes_related_section() -> None:
+    issue = {"title": "Bug", "body": "Details", "related": [{"title": "Doc1"}, {"title": "Doc2"}]}
+    output = build_prompt(issue, mode="scan")
+    data = json.loads(output)
+    assert "Related Knowledge" in data["prompt"]
+    assert "\u2022 Doc1" in data["prompt"]
+    assert "\u2022 Doc2" in data["prompt"]
+
+
+def test_modes_produce_valid_json() -> None:
+    issue = {"title": "Bug"}
+    for m in ["scan", "fix", "pr", "log"]:
+        out = build_prompt(issue, mode=m)
+        data = json.loads(out)
+        assert data["mode"] == m
+        assert isinstance(data["prompt"], str)


### PR DESCRIPTION
## Summary
- implement `core.prompt_manager.build_prompt` with optional related knowledge section
- ensure modes stay valid and return JSON
- test prompt injection for related knowledge addition

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68865fc639148326adce7e323423c54e