### PR TITLE
chore: migrate to LangChain v0.2 import paths

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 langchain>=0.2.0
 langchain-openai
 langchain-community
+langchain-huggingface
 faiss-cpu
 unstructured
 tiktoken

--- a/tests/test_langchain_imports.py
+++ b/tests/test_langchain_imports.py
@@ -1,0 +1,13 @@
+import importlib
+import warnings
+
+
+def test_imports() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        importlib.import_module("langchain_huggingface")
+        from langchain_huggingface import HuggingFaceEmbeddings  # noqa: F401
+        from langchain_openai import OpenAIEmbeddings  # noqa: F401
+        from langchain_community.document_loaders import TextLoader  # noqa: F401
+        from langchain.memory import ConversationBufferMemory  # noqa: F401
+    assert not w

--- a/vector_store/quote_embedder.py
+++ b/vector_store/quote_embedder.py
@@ -2,10 +2,10 @@ import json
 import os
 from typing import Any, Dict, List, Optional
 
-from langchain.embeddings import HuggingFaceEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings
 
 try:
-    from langchain.embeddings import OpenAIEmbeddings
+    from langchain_openai import OpenAIEmbeddings
 except ImportError:
     OpenAIEmbeddings = None
 # Removed redundant import of Optional


### PR DESCRIPTION
### Why
Stop deprecation spam and prepare for LangChain 1.0.

### What
- Rewrites embeddings imports to new split packages
- Adds langchain-huggingface to requirements
- Adds smoke test for new import paths

Closes #LANGCHAIN-MIGRATE-001

------
https://chatgpt.com/codex/tasks/task_e_6886baadefd48326a54738d4cc55260f