### PR TITLE
feat: wire up quoting agent and core pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A new project repository.
 
+## Wire-up Branch (wireup-1.1)
+
+This branch wires together the core quoting pipeline (CLI → prompt manager → quoting agent) and adds
+stubs for future specification and evaluation modules. No new features are introduced.
+
 ## Quick Start
 
 1. Copy `.env.example` to `.env` and fill in any API keys.

--- a/agents/gui_agent.py
+++ b/agents/gui_agent.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+
 class GUIAgent:
     """Minimal GUI agent used for CLI chat."""
 
-    def process_user_input(self, message: str, session_state: dict | None = None) -> str:
+    def process_user_input(
+        self, message: str, session_state: dict[str, str] | None = None
+    ) -> str:
         return f"Echo: {message}"

--- a/agents/quoting_agent.py
+++ b/agents/quoting_agent.py
@@ -1,0 +1,12 @@
+"""Minimal quoting agent — replace with real LLM calls later."""
+
+
+class QuotingAgent:
+    def __init__(self) -> None:
+        """Initialize the quoting agent."""
+        # In real usage you would set up an OpenAI / Ollama client here
+        pass
+
+    def run(self, prompt: str) -> str:
+        """Return a deterministic placeholder response for the given ``prompt``."""
+        return "Quote calculated successfully. (Stub)\n" "Prompt received:\n" + prompt

--- a/agents/spec_guard.py
+++ b/agents/spec_guard.py
@@ -1,0 +1,9 @@
+"""Stub grading utility — always passes for now."""
+
+from typing import Any, Dict, Optional
+
+
+def grade_response(
+    prompt: str, response: str, rules: Optional[Dict[str, Any]] | None = None
+) -> Dict[str, Any]:
+    return {"score": 1.0, "passed": ["stub"], "failures": []}

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,8 @@
+"""Thin wrapper so users can type `python cli.py --prompt "..."`. Calls main.py."""
+
+import subprocess
+import sys
+
+
+if __name__ == "__main__":
+    subprocess.run([sys.executable, "main.py", *sys.argv[1:]], check=True)

--- a/core/spec_loader.py
+++ b/core/spec_loader.py
@@ -1,0 +1,5 @@
+"""Stub implementation — future spec logic will go here."""
+
+
+def load_spec(name: str) -> str:
+    return "Spec loading not yet implemented"

--- a/main.py
+++ b/main.py
@@ -1,0 +1,23 @@
+"""Unified entry-point for the quoting AI system."""
+
+import argparse
+from orchestrator import Orchestrator
+
+
+def parse_args() -> str:
+    parser = argparse.ArgumentParser(description="Quoting AI entry-point")
+    parser.add_argument("--prompt", required=True, help="User prompt for quoting agent")
+    args = parser.parse_args()
+    return str(args.prompt)
+
+
+def main() -> None:
+    user_prompt = parse_args()
+    orchestrator = Orchestrator()
+    response = orchestrator.run(user_prompt)
+    print("\n=== AI Response ===\n")
+    print(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,25 @@
+"""Orchestrates the flow Prompt → Agent → Response."""
+
+from pathlib import Path
+
+from prompt_manager import PromptManager
+from agents.quoting_agent import QuotingAgent
+
+_LOG_DIR = Path(__file__).parent / "logs"
+_LOG_DIR.mkdir(exist_ok=True)
+
+
+class Orchestrator:
+    def __init__(self) -> None:
+        self.prompt_mgr: PromptManager = PromptManager()
+        self.agent: QuotingAgent = QuotingAgent()
+
+    def run(self, user_prompt: str, *, dev_mode: bool = False) -> str:
+        prompt = self.prompt_mgr.build_prompt(user_prompt, dev_mode=dev_mode)
+        response = self.agent.run(prompt)
+
+        # very simple log
+        log_file = _LOG_DIR / "run_history.log"
+        with log_file.open("a", encoding="utf-8", errors="ignore") as fh:
+            fh.write(f"PROMPT: {user_prompt}\nRESPONSE: {response}\n\n")
+        return response

--- a/prompt_manager.py
+++ b/prompt_manager.py
@@ -1,0 +1,8 @@
+class PromptManager:
+    def build_prompt(self, user_prompt: str, dev_mode: bool = False) -> str:
+        """Return the full prompt that will be sent to the quoting agent."""
+        header = "# Quoting Prompt\n"
+        body = user_prompt.strip()
+        if dev_mode:
+            body += "\n\n[DEV MODE ENABLED]"
+        return f"{header}{body}"

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,14 @@
+import streamlit as st
+
+from orchestrator import Orchestrator
+
+
+st.title("925stackai – Quoting Demo (wire-up)")
+
+user_prompt = st.text_input("Enter a prompt to quote:")
+
+if st.button("Generate Quote") and user_prompt:
+    orchestrator = Orchestrator()
+    response = orchestrator.run(user_prompt)
+    st.markdown("### Response")
+    st.write(response)


### PR DESCRIPTION
### Summary
* Added entry scripts and orchestrator to connect CLI input with a stubbed quoting agent.
* Implemented simple prompt builder and logging.
* Provided a Streamlit demo and placeholder spec loader/guard modules.

### Testing
- `mypy main.py cli.py orchestrator.py prompt_manager.py agents/quoting_agent.py agents/spec_guard.py core/spec_loader.py streamlit_app.py`
- `pytest -q` *(fails: ModuleNotFoundError / KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_688731858a248326a005f8f2ea54771a